### PR TITLE
Added install of idna-2.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN set -ex; \
 	\
 	(find /opt/certbot/src -type d \( -name tests -o -name docs -o -name examples \) -exec rm -rf "{}" \; 2>/dev/null || true ); \
 	\
+	pip install --no-cache-dir idna==2.5 ; \
 	pip install --no-cache-dir \
 		--editable /opt/certbot/src/acme \
 		--editable /opt/certbot/src ; \


### PR DESCRIPTION
Since by default pip install idna-2.6, which doesn't meet requirments:
```
# certbot renew
Traceback (most recent call last):
  File "/usr/local/bin/certbot", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3037, in <module>
    @_call_aside
  File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3021, in _call_aside
    f(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3050, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 657, in _build_master
    return cls._build_from_requirements(__requires__)
  File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 670, in _build_from_requirements
    dists = ws.resolve(reqs, Environment())
  File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 860, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (idna 2.6 (/usr/local/lib/python2.7/site-packages), Requirement.parse('idna<2.6,>=2.5'), set(['requests']))
```